### PR TITLE
Adding functionality to check for stage local chart or default to global chart

### DIFF
--- a/stages/dev/infrastructure-charts/templates/applications.yaml
+++ b/stages/dev/infrastructure-charts/templates/applications.yaml
@@ -27,7 +27,15 @@ spec:
     server: https://kubernetes.default.svc
     namespace: {{ (index $.Values $chartName).namespace }}
   source:
-    path: {{$.Values.global.source.appsBasePath | replace "$STAGE" $.Values.global.stage }}/{{ $chartName }}
+
+    {{- $localChartPath := print ($.Values.global.source.appsBasePath | replace "$STAGE" $.Values.global.stage) "/" $chartName }}
+    {{- $relativeLocalChartPath := (print (base $.Values.global.source.appsBasePath) "/" $chartName "/*") }}
+    {{ if $.Files.Glob  $relativeLocalChartPath -}}
+    path: {{ $localChartPath}}
+    {{- else -}}
+    path: {{ print $.Values.global.chartPath "/" $chartName}}
+    {{- end }}
+    
     repoURL: {{ $.Values.global.source.repoURL }}
     targetRevision: {{ $.Values.global.source.targetRevision }}
     helm:

--- a/stages/dev/infrastructure-charts/values.yaml
+++ b/stages/dev/infrastructure-charts/values.yaml
@@ -1,4 +1,5 @@
 global:
+  chartPath: "apps"
   helmValues:
     - name: stage
       value: $STAGE


### PR DESCRIPTION
This branch introduces functionality to the ArgoCD application to check whetever a chart is present in the stage local scope or default to the global scope.

This is useful if you have a Helm Chart which has no stage specific settings. Then you simply place it in the global apps directory and not in the stage local apps directory. Then this template will automatically detect it and choose the global one. This helps reducing duplication.