### PR TITLE
Fix(kafka): Turned off kafka metrics to not use unavailable bitnami image

### DIFF
--- a/infrastructure-charts/value-files/kafka/values.yaml
+++ b/infrastructure-charts/value-files/kafka/values.yaml
@@ -1,0 +1,4 @@
+kafka:
+  metrics:
+    kafka:
+      enabled: false

--- a/infrastructure-charts/values.yaml
+++ b/infrastructure-charts/values.yaml
@@ -29,9 +29,11 @@ charts:
 
   kafka:
     namespace: kafka
-    targetRevision: 22.1.6
+    targetRevision: 22.2.0-bitnamilegacy
+    valueFile: "value-files/kafka/values.yaml"
     parameters:
       "kafka.replicaCount": "1"
+
 #   Remote chart from public helm repo
 #  bitnami-kafka:
 #    namespace: bitnami-kafka # Which namespace should the service be deployed


### PR DESCRIPTION
Turned off Kafka exporter, as there is no bitnamilegacy image available